### PR TITLE
Fix commerce products criteria

### DIFF
--- a/services/AmSearch_SearchService.php
+++ b/services/AmSearch_SearchService.php
@@ -192,6 +192,11 @@ class AmSearch_SearchService extends BaseApplicationComponent
                         unset($sourcesCriteria['editable']);
                     }
                     break;
+                case 'Commerce_Product':
+                    if (isset($sourcesCriteria['editable'])) {
+                        unset($sourcesCriteria['editable']);
+                    }
+                    break;
             }
 
             // Set all criteria now!


### PR DESCRIPTION
I was having an issue where commerce products would not appear in search results unless logged in - looks like the same issue that was fixed for Entries in d3fbb2fe solves the issue for Products as well.